### PR TITLE
Export the registercontract method

### DIFF
--- a/packages/contracts/src/index.tsx
+++ b/packages/contracts/src/index.tsx
@@ -6,4 +6,5 @@ export * from './types'
 export * from './useContractValue'
 export * from './useSendTransaction'
 export * from './wrapStellarAsset'
+export * from './useRegisteredContract'
 


### PR DESCRIPTION
Due to local environment, I had not noticed the function was not exported in the contracts package.
@esteblock 