### PR TITLE
add server as param to soroban react provider

### DIFF
--- a/packages/core/src/SorobanReactProvider.tsx
+++ b/packages/core/src/SorobanReactProvider.tsx
@@ -1,10 +1,10 @@
 import { Connector, WalletChain } from '@soroban-react/types'
+import { ContractDeploymentInfo } from '@soroban-react/types'
 import React, { useRef } from 'react'
 
 import * as StellarSdk from '@stellar/stellar-sdk'
 
 import { SorobanContext, SorobanContextType, defaultSorobanContext } from '.'
-import { ContractDeploymentInfo } from '@soroban-react/types'
 
 /**
  * Props for the SorobanReactProvider component.
@@ -17,7 +17,7 @@ export interface SorobanReactProviderProps {
   children: React.ReactNode
   connectors: Connector[]
   server?: StellarSdk.SorobanRpc.Server // To set on frontend to define the default server url for read-only. Example 'new Server('http://localhost:8000/soroban/rpc',{allowHttp:true})'
-  serverHorizon?: StellarSdk.Horizon.Server,
+  serverHorizon?: StellarSdk.Horizon.Server
   deployments?: ContractDeploymentInfo[]
 }
 
@@ -51,7 +51,9 @@ function networkToActiveChain(networkDetails: any, chains: any) {
  * @param {string} sorobanRpcUrl - Soroban RPC URL.
  * @returns {StellarSdk.SorobanRpc.Server} - Soroban RPC server object.
  */
-function fromURLToServer(sorobanRpcUrl: string): StellarSdk.SorobanRpc.Server {
+export function fromURLToServer(
+  sorobanRpcUrl: string
+): StellarSdk.SorobanRpc.Server {
   return new StellarSdk.SorobanRpc.Server(sorobanRpcUrl, {
     allowHttp: sorobanRpcUrl.startsWith('http://'),
   })
@@ -62,7 +64,9 @@ function fromURLToServer(sorobanRpcUrl: string): StellarSdk.SorobanRpc.Server {
  * @param {string} networkUrl - Network URL.
  * @returns {StellarSdk.Horizon.Server} - Horizon server object.
  */
-function fromURLToHorizonServer(networkUrl: string): StellarSdk.Horizon.Server {
+export function fromURLToHorizonServer(
+  networkUrl: string
+): StellarSdk.Horizon.Server {
   return new StellarSdk.Horizon.Server(networkUrl, {
     allowHttp: networkUrl.startsWith('http://'),
   })
@@ -80,15 +84,15 @@ export function SorobanReactProvider({
   activeChain = defaultSorobanContext.activeChain, // Non mandatory fields default to default Context fields value
   children,
   connectors,
-  deployments = []
-  // server = defaultSorobanContext.server, // Non mandatory fields default to default Context fields value
-  // serverHorizon = defaultSorobanContext.serverHorizon,
+  deployments = [],
+  server = defaultSorobanContext.server,
+  serverHorizon = defaultSorobanContext.serverHorizon,
 }: SorobanReactProviderProps) {
-  const activeConnector = connectors.length && connectors.length > 1 ? connectors[1] : connectors[0]
+  const activeConnector =
+    connectors.length && connectors.length > 1 ? connectors[1] : connectors[0]
   // const activeConnector = undefined
   const isConnectedRef = useRef(false)
-  console.log("SorobanReactProvider is RELOADED")
-  let server: StellarSdk.SorobanRpc.Server | undefined = defaultSorobanContext.server, serverHorizon : StellarSdk.Horizon.Server | undefined= defaultSorobanContext.serverHorizon
+  console.log('SorobanReactProvider is RELOADED')
   if (activeChain?.sorobanRpcUrl) {
     server = fromURLToServer(activeChain.sorobanRpcUrl)
   }
@@ -110,26 +114,25 @@ export function SorobanReactProvider({
       server,
       serverHorizon,
       connect: async () => {
-        console.log("ENTERING CONNECT with context: ",mySorobanContext)
+        console.log('ENTERING CONNECT with context: ', mySorobanContext)
         if (mySorobanContext.activeConnector) {
           // Now we will check if the wallet is freighter so that we keep the old way of choosing the network from the wallet for backward compatibility
-          if (mySorobanContext.activeConnector.id === "freighter") {
+          if (mySorobanContext.activeConnector.id === 'freighter') {
             let networkDetails =
-            await mySorobanContext.activeConnector.getNetworkDetails()
+              await mySorobanContext.activeConnector.getNetworkDetails()
             let activeChain = networkToActiveChain(networkDetails, chains)
-  
-            
+
             if (
               !chains.find(
                 (c: any) =>
-                c.networkPassphrase === networkDetails?.networkPassphrase
-                )
+                  c.networkPassphrase === networkDetails?.networkPassphrase
+              )
             ) {
               const error = new Error(
                 'Your Wallet network is not supported in this app'
-                )
-                throw error
-              }
+              )
+              throw error
+            }
 
             if (!networkDetails?.sorobanRpcUrl) {
               const error = new Error(
@@ -137,27 +140,28 @@ export function SorobanReactProvider({
               )
               throw error
             }
-  
+
             server =
               networkDetails &&
               new StellarSdk.SorobanRpc.Server(networkDetails.sorobanRpcUrl, {
                 allowHttp: networkDetails.sorobanRpcUrl.startsWith('http://'),
               })
-  
+
             serverHorizon =
               networkDetails &&
               new StellarSdk.Horizon.Server(networkDetails.networkUrl, {
                 allowHttp: networkDetails.networkUrl.startsWith('http://'),
               })
-          
-            console.log("SorobanReactProvider: Connecting with FREIGHTER : ", mySorobanContext.activeConnector.name)
+
+            console.log(
+              'SorobanReactProvider: Connecting with FREIGHTER : ',
+              mySorobanContext.activeConnector.name
+            )
             let address = await mySorobanContext.activeConnector.getPublicKey()
-        
-  
-  
+
             // Now we can track that the wallet is finally connected
             isConnectedRef.current = true
-  
+
             setSorobanContext((c: any) => ({
               ...c,
               activeChain,
@@ -167,22 +171,24 @@ export function SorobanReactProvider({
             }))
           }
           // If connector is any other wallet that does not have getNetworkDetails we will need to set the active chain and server from somewehere else in the front end
-          else { 
-              console.log("SorobanReactProvider: Connecting with ", mySorobanContext.activeConnector.name)
-              let address = await mySorobanContext.activeConnector.getPublicKey()
-    
-              // Now we can track that the wallet is finally connected
-              isConnectedRef.current = true
-    
-              setSorobanContext((c: any) => ({
-                ...c,
-                address,
-              }))
+          else {
+            console.log(
+              'SorobanReactProvider: Connecting with ',
+              mySorobanContext.activeConnector.name
+            )
+            let address = await mySorobanContext.activeConnector.getPublicKey()
+
+            // Now we can track that the wallet is finally connected
+            isConnectedRef.current = true
+
+            setSorobanContext((c: any) => ({
+              ...c,
+              address,
+            }))
           }
-      }
-      else {
-        console.log("SorobanReactProvider: No active Connector")
-      }
+        } else {
+          console.log('SorobanReactProvider: No active Connector')
+        }
       },
       disconnect: async () => {
         isConnectedRef.current = false
@@ -191,14 +197,15 @@ export function SorobanReactProvider({
         let address: string | undefined = undefined
         setSorobanContext((c: any) => ({
           ...c,
-          address
+          address,
         }))
       },
 
       setActiveChain: (chain: WalletChain) => {
         console.log('Chainging activeChain to : ', chain)
         // When the user in frontend changes the activeChain to read the blockchain without wallet
-        let server: StellarSdk.SorobanRpc.Server | undefined = undefined, serverHorizon : StellarSdk.Horizon.Server | undefined= undefined
+        let server: StellarSdk.SorobanRpc.Server | undefined = undefined,
+          serverHorizon: StellarSdk.Horizon.Server | undefined = undefined
         activeChain = chain
         if (activeChain.sorobanRpcUrl) {
           server = fromURLToServer(activeChain.sorobanRpcUrl)
@@ -216,21 +223,24 @@ export function SorobanReactProvider({
       },
 
       setActiveConnectorAndConnect: async (connector: Connector) => {
-        console.log("Changing connector to ", connector.name)
+        console.log('Changing connector to ', connector.name)
         let activeConnector = connector
-        console.log("SorobanReactProvider: Changing connector")
+        console.log('SorobanReactProvider: Changing connector')
         // We better connect here otherwise in the frontend the context is not updated fast enough, and the user connects to the old connector first.
         let address = await activeConnector.getPublicKey()
         isConnectedRef.current = true
         setSorobanContext((c: any) => ({
           ...c,
           activeConnector,
-          address
+          address,
         }))
-      }
+      },
     })
 
-    console.log("SorobanReactProvider: Active connector is ", mySorobanContext.activeConnector?.name)
+  console.log(
+    'SorobanReactProvider: Active connector is ',
+    mySorobanContext.activeConnector?.name
+  )
 
   // Handle changes of address in "realtime"
   React.useEffect(() => {
@@ -252,56 +262,54 @@ export function SorobanReactProvider({
       )
         return
       // For now we can only do this with freighter. xBull doesn't handle the repeated call well.
-      else if (mySorobanContext.activeConnector.id !== "freighter") {
+      else if (mySorobanContext.activeConnector.id !== 'freighter') {
         return
-      }
-      else {
+      } else {
         let hasNoticedWalletUpdate = false
 
         try {
-          
           // NOTICE: If the user logs out from or uninstalls the Freighter extension while they are connected
-        // on this site, then a dialog will appear asking them to sign in again. We need a way to ask Freighter
-        // if there is _any_ connected user, without actually asking them to sign in. Unfortunately, that is not
-        // supported at this time; but it would be easy to submit a PR to the extension to add support for it.
-        let address = await mySorobanContext.activeConnector?.getPublicKey()
-        
-        // TODO: If you want to know when the user has disconnected, then you can set a timeout for getPublicKey.
-        // If it doesn't return in X milliseconds, you can be pretty confident that they aren't connected anymore.
-        
-        if (mySorobanContext.address !== address) {
-          console.log(
-            'SorobanReactProvider: address changed from:',
-            mySorobanContext.address,
-            ' to: ',
-            address
+          // on this site, then a dialog will appear asking them to sign in again. We need a way to ask Freighter
+          // if there is _any_ connected user, without actually asking them to sign in. Unfortunately, that is not
+          // supported at this time; but it would be easy to submit a PR to the extension to add support for it.
+          let address = await mySorobanContext.activeConnector?.getPublicKey()
+
+          // TODO: If you want to know when the user has disconnected, then you can set a timeout for getPublicKey.
+          // If it doesn't return in X milliseconds, you can be pretty confident that they aren't connected anymore.
+
+          if (mySorobanContext.address !== address) {
+            console.log(
+              'SorobanReactProvider: address changed from:',
+              mySorobanContext.address,
+              ' to: ',
+              address
             )
             hasNoticedWalletUpdate = true
-            
+
             console.log('SorobanReactProvider: reconnecting')
             setSorobanContext((c: any) => ({
               ...c,
               address,
             }))
-          } 
+          }
         } catch (error) {
           // I would recommend keeping the try/catch so that any exceptions in this async function
           // will get handled. Otherwise React could complain. I believe that eventually it may cause huge
           // problems, but that might be a NodeJS specific approach to exceptions not handled in promises.
 
-        console.error('SorobanReactProvider: error: ', error)
-      } finally {
-        if (!hasNoticedWalletUpdate)
-        timeoutId = setTimeout(
-            checkForAddressChanges,
-            freighterCheckIntervalMs
-          )
+          console.error('SorobanReactProvider: error: ', error)
+        } finally {
+          if (!hasNoticedWalletUpdate)
+            timeoutId = setTimeout(
+              checkForAddressChanges,
+              freighterCheckIntervalMs
+            )
+        }
       }
     }
-    }
-    
+
     checkForAddressChanges()
-    
+
     return () => {
       if (timeoutId != null) clearTimeout(timeoutId)
     }
@@ -323,20 +331,22 @@ export function SorobanReactProvider({
       )
         return
       // For now we can only do this with freighter. xBull doesn't have the getNetworkDetails method exposed.
-      else if (mySorobanContext.activeConnector.id !== "freighter") {
+      else if (mySorobanContext.activeConnector.id !== 'freighter') {
         return
-      }
-      else {
-
+      } else {
         let hasNoticedWalletUpdate = false
-  
-        try {
 
-          let networkDetails = await mySorobanContext.activeConnector.getNetworkDetails()
+        try {
+          let networkDetails =
+            await mySorobanContext.activeConnector.getNetworkDetails()
           let newActiveChain = networkToActiveChain(networkDetails, chains)
-  
+
           // We check that we have a valid network details and not a blank one like the one xbull connector would return
-          if (networkDetails.network && newActiveChain.networkPassphrase !== mySorobanContext.activeChain.networkPassphrase) {
+          if (
+            networkDetails.network &&
+            newActiveChain.networkPassphrase !==
+              mySorobanContext.activeChain.networkPassphrase
+          ) {
             console.log(
               'SorobanReactProvider: network changed from:',
               mySorobanContext.activeChain.networkPassphrase,
@@ -344,12 +354,11 @@ export function SorobanReactProvider({
               newActiveChain.networkPassphrase
             )
             hasNoticedWalletUpdate = true
-  
 
-            mySorobanContext.setActiveChain && mySorobanContext.setActiveChain(newActiveChain)
-          } 
+            mySorobanContext.setActiveChain &&
+              mySorobanContext.setActiveChain(newActiveChain)
+          }
         } catch (error) {
-  
           console.error('SorobanReactProvider: error: ', error)
         } finally {
           if (!hasNoticedWalletUpdate)
@@ -367,7 +376,7 @@ export function SorobanReactProvider({
       if (timeoutId != null) clearTimeout(timeoutId)
     }
   }, [mySorobanContext])
-  
+
   // TODO: ASSESS THE USE OF THIS
   // React.useEffect(() => {
   //   if (mySorobanContext.address) return // If we already have access to the connector's address, we are OK


### PR DESCRIPTION
this pr solves #90 

now you can set the value for the default rpc in the soroban react provider

usage:

```ts
 <SorobanReactProvider
  server={fromURLToServer(
    'https://testnet.stellar.validationcloud.io/v1/Mewk7YPYiUy3wAlDNlQsIhwxbdumICRYrz2tXS2vOck',
  )}
>
  {children}
</SorobanReactProvider>
```
there is still a problem that when you connect your wallet it is not taking the rpc from your wallet, i think the soroban provider needs to be refactor
